### PR TITLE
Upgrade to Spring Boot 4.0.5

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 config.stopBubbling = true
 lombok.addLombokGeneratedAnnotation = true
+lombok.jacksonized.jacksonVersion += 3

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <spring-boot.version>4.0.5</spring-boot.version>
-    <lombok.version>1.18.42</lombok.version>
+    <jackson-bom.version>3.1.0</jackson-bom.version>
+    <lombok.version>1.18.44</lombok.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <reflections.version>0.10.2</reflections.version>
 
@@ -87,6 +88,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.queritylib</groupId>
   <artifactId>querity-parent</artifactId>
-  <version>3.6.3-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Querity</name>
@@ -50,7 +50,7 @@
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <spring-boot.version>3.5.7</spring-boot.version>
+    <spring-boot.version>4.0.5</spring-boot.version>
     <lombok.version>1.18.42</lombok.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <reflections.version>0.10.2</reflections.version>
@@ -90,32 +90,32 @@
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-api</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-common</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-jpa-common</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-jpa-common-test</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-parser</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.github.queritylib</groupId>
         <artifactId>querity-test</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/querity-api/pom.xml
+++ b/querity-api/pom.xml
@@ -13,7 +13,6 @@
   <description>Core module of Querity containing the public API</description>
 
   <properties>
-    <jackson.version>2.21.1</jackson.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.22.0</mockito.version>
@@ -22,9 +21,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/querity-api/pom.xml
+++ b/querity-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>querity-api</artifactId>

--- a/querity-common/pom.xml
+++ b/querity-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>querity-common</artifactId>
@@ -13,7 +13,7 @@
   <description>Common utilities and classes for Querity</description>
 
   <properties>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.21.1</jackson.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.22.0</mockito.version>

--- a/querity-common/pom.xml
+++ b/querity-common/pom.xml
@@ -13,7 +13,6 @@
   <description>Common utilities and classes for Querity</description>
 
   <properties>
-    <jackson.version>2.21.1</jackson.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.22.0</mockito.version>

--- a/querity-jpa-common-test/pom.xml
+++ b/querity-jpa-common-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -13,7 +13,7 @@
   <description>Test utilities for JPA based Querity implementations</description>
 
   <properties>
-    <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
+    <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <assertj.version>3.27.7</assertj.version>
   </properties>

--- a/querity-jpa-common/pom.xml
+++ b/querity-jpa-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -13,8 +13,8 @@
   <description>Common code for JPA based Querity implementations</description>
 
   <properties>
-    <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
-    <hibernate.version>6.6.44.Final</hibernate.version>
+    <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
+    <hibernate.version>7.2.7.Final</hibernate.version>
     <junit-jupiter.version>5.12.1</junit-jupiter.version>
     <assertj.version>3.27.3</assertj.version>
   </properties>

--- a/querity-jpa-common/src/test/java/io/github/queritylib/querity/jpa/QueritySpringJpaTestApplication.java
+++ b/querity-jpa-common/src/test/java/io/github/queritylib/querity/jpa/QueritySpringJpaTestApplication.java
@@ -5,7 +5,7 @@ import io.github.queritylib.querity.jpa.domain.Person;
 import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication

--- a/querity-jpa/pom.xml
+++ b/querity-jpa/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -15,8 +15,8 @@
   </description>
 
   <properties>
-    <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
-    <hibernate.version>6.6.44.Final</hibernate.version>
+    <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
+    <hibernate.version>7.2.7.Final</hibernate.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.22.0</mockito.version>
@@ -47,6 +47,12 @@
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
       <version>${jakarta.persistence.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>3.0.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate.orm</groupId>

--- a/querity-jpa/src/main/java/io/github/queritylib/querity/jpa/Specification.java
+++ b/querity-jpa/src/main/java/io/github/queritylib/querity/jpa/Specification.java
@@ -5,7 +5,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.Objects;
 
 @FunctionalInterface

--- a/querity-parser/pom.xml
+++ b/querity-parser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>querity-parser</artifactId>

--- a/querity-spring-data-elasticsearch/pom.xml
+++ b/querity-spring-data-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/querity-spring-data-elasticsearch/src/main/resources/META-INF/spring.factories
+++ b/querity-spring-data-elasticsearch/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.queritylib.querity.spring.data.elasticsearch.QuerityElasticsearchAutoConfiguration

--- a/querity-spring-data-elasticsearch/src/test/java/io/github/queritylib/querity/spring/data/elasticsearch/QuerityElasticsearchImplTests.java
+++ b/querity-spring-data-elasticsearch/src/test/java/io/github/queritylib/querity/spring/data/elasticsearch/QuerityElasticsearchImplTests.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Testcontainers
 class QuerityElasticsearchImplTests extends QuerityGenericSpringTestSuite<Person, String> {
 
-  private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.16.5";
+  private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:9.2.6";
 
   @Container
   private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(DockerImageName.parse(ELASTICSEARCH_IMAGE))

--- a/querity-spring-data-jpa/pom.xml
+++ b/querity-spring-data-jpa/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/querity-spring-data-jpa/src/main/resources/META-INF/spring.factories
+++ b/querity-spring-data-jpa/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.queritylib.querity.spring.data.jpa.QuerityJpaAutoConfiguration

--- a/querity-spring-data-jpa/src/test/java/io/github/queritylib/querity/spring/data/jpa/QueritySpringJpaTestApplication.java
+++ b/querity-spring-data-jpa/src/test/java/io/github/queritylib/querity/spring/data/jpa/QueritySpringJpaTestApplication.java
@@ -3,7 +3,7 @@ package io.github.queritylib.querity.spring.data.jpa;
 import io.github.queritylib.querity.jpa.domain.Person;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 
 @SpringBootApplication
 @EntityScan(basePackageClasses = Person.class)

--- a/querity-spring-data-mongodb/pom.xml
+++ b/querity-spring-data-mongodb/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/querity-spring-data-mongodb/src/main/resources/META-INF/spring.factories
+++ b/querity-spring-data-mongodb/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.queritylib.querity.spring.data.mongodb.QuerityMongodbAutoConfiguration

--- a/querity-spring-data-mongodb/src/test/java/io/github/queritylib/querity/spring/data/mongodb/QuerityMongodbImplTests.java
+++ b/querity-spring-data-mongodb/src/test/java/io/github/queritylib/querity/spring/data/mongodb/QuerityMongodbImplTests.java
@@ -37,7 +37,7 @@ class QuerityMongodbImplTests extends QuerityGenericSpringTestSuite<Person, Stri
 
   @DynamicPropertySource
   static void setProperties(DynamicPropertyRegistry registry) {
-    registry.add("spring.data.mongodb.uri", MONGO_DB_CONTAINER::getReplicaSetUrl);
+    registry.add("spring.mongodb.uri", MONGO_DB_CONTAINER::getReplicaSetUrl);
   }
 
   @Override

--- a/querity-spring-data-mongodb/src/test/resources/application.yml
+++ b/querity-spring-data-mongodb/src/test/resources/application.yml
@@ -1,1 +1,6 @@
-spring.main.banner-mode: off
+spring:
+  main:
+    banner-mode: off
+  mongodb:
+    representation:
+      uuid: java-legacy

--- a/querity-spring-web/pom.xml
+++ b/querity-spring-web/pom.xml
@@ -24,10 +24,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-jackson2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
@@ -44,7 +40,7 @@
       <artifactId>aspectjweaver</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/querity-spring-web/pom.xml
+++ b/querity-spring-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +22,10 @@
       <artifactId>querity-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson2</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
@@ -53,12 +57,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/QueritySpringWebAutoConfiguration.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/QueritySpringWebAutoConfiguration.java
@@ -1,6 +1,6 @@
 package io.github.queritylib.querity.spring.web;
 
-import com.fasterxml.jackson.databind.Module;
+import tools.jackson.databind.JacksonModule;
 import io.github.queritylib.querity.spring.web.jackson.QuerityModule;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnProperty(prefix = "querity.web.autoconfigure", name = "enabled", matchIfMissing = true)
 public class QueritySpringWebAutoConfiguration {
   @Bean
-  public Module querityJacksonModule() {
+  public JacksonModule querityJacksonModule() {
     return new QuerityModule();
   }
 

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/QuerityWebMvcSupport.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/QuerityWebMvcSupport.java
@@ -1,6 +1,6 @@
 package io.github.queritylib.querity.spring.web;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.github.queritylib.querity.api.AdvancedQuery;
 import io.github.queritylib.querity.api.Condition;
 import io.github.queritylib.querity.api.Query;

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/ConditionDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/ConditionDeserializer.java
@@ -1,14 +1,14 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.*;
 import lombok.SneakyThrows;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -33,7 +33,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
   }
 
   @Override
-  public Condition deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+  public Condition deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parseCondition(root, jsonParser, deserializationContext);
   }
@@ -68,7 +68,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
 
   private static List<Condition> parseConditions(JsonParser jsonParser, JsonNode conditionsJsonNode, DeserializationContext context) {
     return StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(conditionsJsonNode.elements(), Spliterator.ORDERED),
+            Spliterators.spliteratorUnknownSize(conditionsJsonNode.iterator(), Spliterator.ORDERED),
             false)
         .map(n -> parseCondition(n, jsonParser, context))
         .collect(Collectors.toList());
@@ -93,17 +93,17 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
       PropertyExpression leftExpr = context.readTreeAsValue(jsonNode.get(LEFT_EXPRESSION), PropertyExpression.class);
       builder = builder.leftExpression(leftExpr);
     } else {
-      builder = setIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_PROPERTY_NAME, JsonNode::asText, builder::propertyName);
+      builder = setIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_PROPERTY_NAME, JsonNode::asString, builder::propertyName);
     }
     
-    builder = setIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_OPERATOR, node -> Operator.valueOf(node.asText()), builder::operator);
+    builder = setIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_OPERATOR, node -> Operator.valueOf(node.asString()), builder::operator);
 
     // Check if this is a field reference
     if (jsonNode.hasNonNull(FIELD_SIMPLE_CONDITION_FIELD_REF)) {
-      String fieldName = jsonNode.get(FIELD_SIMPLE_CONDITION_FIELD_REF).asText();
+      String fieldName = jsonNode.get(FIELD_SIMPLE_CONDITION_FIELD_REF).asString();
       builder = builder.value(FieldReference.of(fieldName));
     } else if (isArray(jsonNode, FIELD_SIMPLE_CONDITION_VALUE)) {
-      builder = setArrayIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_VALUE, JsonNode::asText, builder::value);
+      builder = setArrayIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_VALUE, JsonNode::asString, builder::value);
     } else {
       builder = setIfNotNull(jsonNode, builder, FIELD_SIMPLE_CONDITION_VALUE, ConditionDeserializer::extractValue, builder::value);
     }
@@ -121,7 +121,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
       if (node.isLong()) return node.asLong();
       return node.asDouble();
     }
-    return node.asText();
+    return node.asString();
   }
 
   private static boolean isArray(JsonNode jsonNode, String fieldName) {
@@ -139,7 +139,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
     if (jsonNode.hasNonNull(fieldName)) {
       JsonNode valueNode = jsonNode.get(fieldName);
       T[] values = (T[]) StreamSupport.stream(
-              Spliterators.spliteratorUnknownSize(valueNode.elements(), Spliterator.ORDERED),
+              Spliterators.spliteratorUnknownSize(valueNode.iterator(), Spliterator.ORDERED),
               false)
           .map(valueProvider)
           .toArray();

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/FunctionArgumentDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/FunctionArgumentDeserializer.java
@@ -1,16 +1,15 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.FunctionArgument;
 import io.github.queritylib.querity.api.FunctionCall;
 import io.github.queritylib.querity.api.Literal;
 import io.github.queritylib.querity.api.PropertyReference;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 import static io.github.queritylib.querity.spring.web.jackson.JsonFields.*;
 
@@ -31,12 +30,12 @@ public class FunctionArgumentDeserializer extends StdDeserializer<FunctionArgume
   }
 
   @Override
-  public FunctionArgument deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+  public FunctionArgument deserialize(JsonParser jsonParser, DeserializationContext context) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parseFunctionArgument(root, context);
   }
 
-  private static FunctionArgument parseFunctionArgument(JsonNode jsonNode, DeserializationContext context) throws IOException {
+  private static FunctionArgument parseFunctionArgument(JsonNode jsonNode, DeserializationContext context) {
     if (jsonNode.hasNonNull(FUNCTION)) {
       return context.readTreeAsValue(jsonNode, FunctionCall.class);
     }

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/GroupByDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/GroupByDeserializer.java
@@ -1,16 +1,16 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.GroupBy;
 import io.github.queritylib.querity.api.PropertyExpression;
 import io.github.queritylib.querity.api.SimpleGroupBy;
 import lombok.SneakyThrows;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -26,7 +26,7 @@ public class GroupByDeserializer extends StdDeserializer<GroupBy> {
   }
 
   @Override
-  public GroupBy deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+  public GroupBy deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parseGroupBy(root, deserializationContext);
   }
@@ -44,9 +44,9 @@ public class GroupByDeserializer extends StdDeserializer<GroupBy> {
   private static SimpleGroupBy parseSimpleGroupBy(JsonNode jsonNode) {
     JsonNode propertyNamesNode = jsonNode.get(PROPERTY_NAMES);
     List<String> propertyNames = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(propertyNamesNode.elements(), Spliterator.ORDERED),
+            Spliterators.spliteratorUnknownSize(propertyNamesNode.iterator(), Spliterator.ORDERED),
             false)
-        .map(JsonNode::asText)
+        .map(JsonNode::asString)
         .toList();
     return SimpleGroupBy.builder()
         .propertyNames(propertyNames)
@@ -57,7 +57,7 @@ public class GroupByDeserializer extends StdDeserializer<GroupBy> {
   private static SimpleGroupBy parseGroupByWithExpressions(JsonNode jsonNode, DeserializationContext context) {
     JsonNode expressionsNode = jsonNode.get(EXPRESSIONS);
     List<PropertyExpression> expressions = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(expressionsNode.elements(), Spliterator.ORDERED),
+            Spliterators.spliteratorUnknownSize(expressionsNode.iterator(), Spliterator.ORDERED),
             false)
         .map(node -> deserializeExpression(node, context))
         .toList();

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/PropertyExpressionDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/PropertyExpressionDeserializer.java
@@ -1,15 +1,14 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.FunctionCall;
 import io.github.queritylib.querity.api.PropertyExpression;
 import io.github.queritylib.querity.api.PropertyReference;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 import static io.github.queritylib.querity.spring.web.jackson.JsonFields.FUNCTION;
 import static io.github.queritylib.querity.spring.web.jackson.JsonFields.PROPERTY_NAME;
@@ -30,12 +29,12 @@ public class PropertyExpressionDeserializer extends StdDeserializer<PropertyExpr
   }
 
   @Override
-  public PropertyExpression deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+  public PropertyExpression deserialize(JsonParser jsonParser, DeserializationContext context) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parsePropertyExpression(root, context);
   }
 
-  private static PropertyExpression parsePropertyExpression(JsonNode jsonNode, DeserializationContext context) throws IOException {
+  private static PropertyExpression parsePropertyExpression(JsonNode jsonNode, DeserializationContext context) {
     if (jsonNode.hasNonNull(FUNCTION)) {
       return context.readTreeAsValue(jsonNode, FunctionCall.class);
     }

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/QuerityDeserializers.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/QuerityDeserializers.java
@@ -1,0 +1,51 @@
+package io.github.queritylib.querity.spring.web.jackson;
+
+import io.github.queritylib.querity.api.Condition;
+import io.github.queritylib.querity.api.FunctionArgument;
+import io.github.queritylib.querity.api.GroupBy;
+import io.github.queritylib.querity.api.PropertyExpression;
+import io.github.queritylib.querity.api.Select;
+import io.github.queritylib.querity.api.Sort;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.Deserializers;
+
+class QuerityDeserializers extends Deserializers.Base {
+  @Override
+  public ValueDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config, BeanDescription.Supplier beanDescSupplier) {
+    Class<?> raw = type.getRawClass();
+    if (Condition.class.isAssignableFrom(raw)) {
+      return new ConditionDeserializer(type);
+    }
+    if (Select.class.isAssignableFrom(raw)) {
+      return new SelectDeserializer(type);
+    }
+    if (Sort.class.isAssignableFrom(raw)) {
+      return new SortDeserializer(type);
+    }
+    if (GroupBy.class.isAssignableFrom(raw)) {
+      return new GroupByDeserializer(type);
+    }
+    // Use exact class match to avoid conflicts between PropertyExpression and FunctionArgument
+    // (PropertyExpression extends FunctionArgument)
+    if (raw == PropertyExpression.class) {
+      return new PropertyExpressionDeserializer(type);
+    }
+    if (raw == FunctionArgument.class) {
+      return new FunctionArgumentDeserializer(type);
+    }
+    return null;
+  }
+
+  @Override
+  public boolean hasDeserializerFor(DeserializationConfig config, Class<?> valueType) {
+    return Condition.class.isAssignableFrom(valueType)
+        || Select.class.isAssignableFrom(valueType)
+        || Sort.class.isAssignableFrom(valueType)
+        || GroupBy.class.isAssignableFrom(valueType)
+        || valueType == PropertyExpression.class
+        || valueType == FunctionArgument.class;
+  }
+}

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/QuerityModule.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/QuerityModule.java
@@ -1,16 +1,9 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.deser.Deserializers;
-import io.github.queritylib.querity.api.Condition;
-import io.github.queritylib.querity.api.FunctionArgument;
-import io.github.queritylib.querity.api.GroupBy;
-import io.github.queritylib.querity.api.PropertyExpression;
-import io.github.queritylib.querity.api.Select;
-import io.github.queritylib.querity.api.Sort;
+import tools.jackson.core.Version;
+import tools.jackson.databind.JacksonModule;
 
-public class QuerityModule extends com.fasterxml.jackson.databind.Module {
+public class QuerityModule extends JacksonModule {
   @Override
   public String getModuleName() {
     return getClass().getSimpleName();
@@ -23,32 +16,6 @@ public class QuerityModule extends com.fasterxml.jackson.databind.Module {
 
   @Override
   public void setupModule(SetupContext setupContext) {
-    setupContext.addDeserializers(new Deserializers.Base() {
-      @Override
-      public JsonDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) throws JsonMappingException {
-        Class<?> raw = type.getRawClass();
-        if (Condition.class.isAssignableFrom(raw)) {
-          return new ConditionDeserializer(type);
-        }
-        if (Select.class.isAssignableFrom(raw)) {
-          return new SelectDeserializer(type);
-        }
-        if (Sort.class.isAssignableFrom(raw)) {
-          return new SortDeserializer(type);
-        }
-        if (GroupBy.class.isAssignableFrom(raw)) {
-          return new GroupByDeserializer(type);
-        }
-        // Use exact class match to avoid conflicts between PropertyExpression and FunctionArgument
-        // (PropertyExpression extends FunctionArgument)
-        if (raw == PropertyExpression.class) {
-          return new PropertyExpressionDeserializer(type);
-        }
-        if (raw == FunctionArgument.class) {
-          return new FunctionArgumentDeserializer(type);
-        }
-        return super.findBeanDeserializer(type, config, beanDesc);
-      }
-    });
+    setupContext.addDeserializers(new QuerityDeserializers());
   }
 }

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/SelectDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/SelectDeserializer.java
@@ -1,16 +1,16 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.PropertyExpression;
 import io.github.queritylib.querity.api.Select;
 import io.github.queritylib.querity.api.SimpleSelect;
 import lombok.SneakyThrows;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -26,7 +26,7 @@ public class SelectDeserializer extends StdDeserializer<Select> {
   }
 
   @Override
-  public Select deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+  public Select deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parseSelect(root, deserializationContext);
   }
@@ -44,9 +44,9 @@ public class SelectDeserializer extends StdDeserializer<Select> {
   private static SimpleSelect parseSimpleSelect(JsonNode jsonNode) {
     JsonNode propertyNamesNode = jsonNode.get(PROPERTY_NAMES);
     List<String> propertyNames = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(propertyNamesNode.elements(), Spliterator.ORDERED),
+            Spliterators.spliteratorUnknownSize(propertyNamesNode.iterator(), Spliterator.ORDERED),
             false)
-        .map(JsonNode::asText)
+        .map(JsonNode::asString)
         .toList();
     return SimpleSelect.builder()
         .propertyNames(propertyNames)
@@ -57,7 +57,7 @@ public class SelectDeserializer extends StdDeserializer<Select> {
   private static SimpleSelect parseSelectWithExpressions(JsonNode jsonNode, DeserializationContext context) {
     JsonNode expressionsNode = jsonNode.get(EXPRESSIONS);
     List<PropertyExpression> expressions = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(expressionsNode.elements(), Spliterator.ORDERED),
+            Spliterators.spliteratorUnknownSize(expressionsNode.iterator(), Spliterator.ORDERED),
             false)
         .map(node -> deserializeExpression(node, context))
         .toList();

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/SortDeserializer.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/jackson/SortDeserializer.java
@@ -1,14 +1,13 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.queritylib.querity.api.SimpleSort;
 import io.github.queritylib.querity.api.Sort;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 import static io.github.queritylib.querity.spring.web.jackson.JsonFields.DIRECTION;
 import static io.github.queritylib.querity.spring.web.jackson.JsonFields.PROPERTY_NAME;
@@ -20,7 +19,7 @@ public class SortDeserializer extends StdDeserializer<Sort> {
   }
 
   @Override
-  public Sort deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+  public Sort deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws JacksonException {
     JsonNode root = jsonParser.readValueAsTree();
     return parseSort(root);
   }
@@ -39,10 +38,10 @@ public class SortDeserializer extends StdDeserializer<Sort> {
   private static SimpleSort parseSimpleSort(JsonNode jsonNode) {
     SimpleSort.SimpleSortBuilder builder = SimpleSort.builder();
 
-    builder.propertyName(jsonNode.get(PROPERTY_NAME).asText());
+    builder.propertyName(jsonNode.get(PROPERTY_NAME).asString());
 
     if (jsonNode.hasNonNull(DIRECTION)) {
-      builder.direction(SimpleSort.Direction.valueOf(jsonNode.get(DIRECTION).asText()));
+      builder.direction(SimpleSort.Direction.valueOf(jsonNode.get(DIRECTION).asString()));
     }
 
     return builder.build();

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/AbstractJsonPropertyEditor.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/AbstractJsonPropertyEditor.java
@@ -1,7 +1,7 @@
 package io.github.queritylib.querity.spring.web.propertyeditor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.util.StringUtils;
 
@@ -22,7 +22,7 @@ public abstract class AbstractJsonPropertyEditor<T> extends PropertyEditorSuppor
       T value;
       try {
         value = objectMapper.readValue(text, getPropertyClass());
-      } catch (JsonProcessingException e) {
+      } catch (JacksonException e) {
         throw new IllegalArgumentException(e);
       }
       setValue(value);

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/AdvancedQueryJsonPropertyEditor.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/AdvancedQueryJsonPropertyEditor.java
@@ -1,6 +1,6 @@
 package io.github.queritylib.querity.spring.web.propertyeditor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.github.queritylib.querity.api.AdvancedQuery;
 
 public class AdvancedQueryJsonPropertyEditor extends AbstractJsonPropertyEditor<AdvancedQuery> {

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/ConditionJsonPropertyEditor.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/ConditionJsonPropertyEditor.java
@@ -1,6 +1,6 @@
 package io.github.queritylib.querity.spring.web.propertyeditor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.github.queritylib.querity.api.Condition;
 
 public class ConditionJsonPropertyEditor extends AbstractJsonPropertyEditor<Condition> {

--- a/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/QueryJsonPropertyEditor.java
+++ b/querity-spring-web/src/main/java/io/github/queritylib/querity/spring/web/propertyeditor/QueryJsonPropertyEditor.java
@@ -1,6 +1,6 @@
 package io.github.queritylib.querity.spring.web.propertyeditor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.github.queritylib.querity.api.Query;
 
 public class QueryJsonPropertyEditor extends AbstractJsonPropertyEditor<Query> {

--- a/querity-spring-web/src/main/resources/META-INF/spring.factories
+++ b/querity-spring-web/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.queritylib.querity.spring.web.QueritySpringWebAutoConfiguration

--- a/querity-spring-web/src/test/java/io/github/queritylib/querity/spring/web/QueritySpringWebTests.java
+++ b/querity-spring-web/src/test/java/io/github/queritylib/querity/spring/web/QueritySpringWebTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.json.JsonCompareMode;

--- a/querity-spring-web/src/test/java/io/github/queritylib/querity/spring/web/jackson/DeserializerTests.java
+++ b/querity-spring-web/src/test/java/io/github/queritylib/querity/spring/web/jackson/DeserializerTests.java
@@ -1,6 +1,7 @@
 package io.github.queritylib.querity.spring.web.jackson;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import io.github.queritylib.querity.api.*;
 import io.github.queritylib.querity.api.Select;
 import io.github.queritylib.querity.api.SimpleSelect;
@@ -19,8 +20,9 @@ class DeserializerTests {
 
   @BeforeEach
   void setUp() {
-    objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new QuerityModule());
+    objectMapper = JsonMapper.builder()
+        .addModule(new QuerityModule())
+        .build();
   }
 
   @Nested
@@ -219,6 +221,26 @@ class DeserializerTests {
       QuerityModule module = new QuerityModule();
 
       assertThat(module.version()).isNotNull();
+    }
+  }
+
+  @Nested
+  class QuerityDeserializersTests {
+    private final QuerityDeserializers deserializers = new QuerityDeserializers();
+
+    @Test
+    void givenSupportedTypes_whenHasDeserializerFor_thenReturnTrue() {
+      assertThat(deserializers.hasDeserializerFor(null, Condition.class)).isTrue();
+      assertThat(deserializers.hasDeserializerFor(null, Select.class)).isTrue();
+      assertThat(deserializers.hasDeserializerFor(null, Sort.class)).isTrue();
+      assertThat(deserializers.hasDeserializerFor(null, GroupBy.class)).isTrue();
+      assertThat(deserializers.hasDeserializerFor(null, PropertyExpression.class)).isTrue();
+      assertThat(deserializers.hasDeserializerFor(null, FunctionArgument.class)).isTrue();
+    }
+
+    @Test
+    void givenUnsupportedType_whenHasDeserializerFor_thenReturnFalse() {
+      assertThat(deserializers.hasDeserializerFor(null, String.class)).isFalse();
     }
   }
 

--- a/querity-spring-web/src/test/resources/application.yml
+++ b/querity-spring-web/src/test/resources/application.yml
@@ -1,6 +1,3 @@
 spring:
   main:
     banner-mode: off
-  http:
-    converters:
-      preferred-json-mapper: jackson2

--- a/querity-spring-web/src/test/resources/application.yml
+++ b/querity-spring-web/src/test/resources/application.yml
@@ -1,1 +1,6 @@
-spring.main.banner-mode: off
+spring:
+  main:
+    banner-mode: off
+  http:
+    converters:
+      preferred-json-mapper: jackson2

--- a/querity-test/pom.xml
+++ b/querity-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>querity-parent</artifactId>
     <groupId>io.github.queritylib</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/querity-test/pom.xml
+++ b/querity-test/pom.xml
@@ -22,10 +22,6 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/querity-test/src/main/java/io/github/queritylib/querity/test/QuerityGenericTestSuite.java
+++ b/querity-test/src/main/java/io/github/queritylib/querity/test/QuerityGenericTestSuite.java
@@ -7,6 +7,7 @@ import io.github.queritylib.querity.test.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringExtensionConfig;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -20,6 +21,7 @@ import static io.github.queritylib.querity.api.SimpleSort.Direction.DESC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+@SpringExtensionConfig(useTestClassScopedExtensionContext = true)
 public abstract class QuerityGenericTestSuite<T extends Person<K, ?, ?, ? extends Order<? extends OrderItem>, ?>, K extends Comparable<K>> {
   protected DatabaseSeeder<T> databaseSeeder;
   protected Querity querity;

--- a/querity-test/src/main/java/io/github/queritylib/querity/test/util/JsonUtils.java
+++ b/querity-test/src/main/java/io/github/queritylib/querity/test/util/JsonUtils.java
@@ -1,7 +1,7 @@
 package io.github.queritylib.querity.test.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
@@ -15,7 +15,7 @@ import java.util.List;
 public class JsonUtils {
   @SuppressWarnings("unchecked")
   public static <T> List<T> readListFromJson(String path, Class<T> entityClass) throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper().registerModules(new JavaTimeModule());
+    ObjectMapper objectMapper = JsonMapper.builder().build();
     Class<T[]> entityArrayClass = (Class<T[]>) Array.newInstance(entityClass, 0).getClass();
     return Arrays.asList(objectMapper.readValue(new ClassPathResource(path).getInputStream(), entityArrayClass));
   }


### PR DESCRIPTION
## Summary

Upgrade Spring Boot from 3.5.7 to 4.0.5, along with all related dependency and API changes required by the new major version, including full migration from Jackson 2 to Jackson 3.

### Dependency upgrades
- **Spring Boot**: 3.5.7 → 4.0.5 (Spring Framework 7.0.6, Spring Data 2025.1.4)
- **Hibernate**: 6.6.44.Final → 7.2.7.Final
- **Jakarta Persistence**: 3.1.0 → 3.2.0
- **Jackson**: 2.21.1 → 3.1.0 (full migration from `com.fasterxml.jackson` to `tools.jackson`)
- **Lombok**: 1.18.42 → 1.18.44 (Jackson 3 support for `@Jacksonized`)
- **Project version**: 3.6.3-SNAPSHOT → 4.0.0-SNAPSHOT
- **Elasticsearch test image**: 8.16.5 → 9.2.6 (matching ES Java client 9.2.6)

### Breaking changes resolved

#### Spring Boot 4 / Spring Framework 7
- `javax.annotation.Nullable` → `jakarta.annotation.Nullable` (Spring Framework 7 dropped javax.annotation support)
- `@EntityScan` import moved to `org.springframework.boot.persistence.autoconfigure` (Boot 4 modularization)
- `@WebMvcTest` import moved to `org.springframework.boot.webmvc.test.autoconfigure` (Boot 4 modularization)
- `spring-boot-starter-web` → `spring-boot-starter-webmvc` (starter rename)
- `spring-boot-starter-test` replaced with `spring-boot-starter-webmvc-test` for web test slice
- Added `@SpringExtensionConfig` on `QuerityGenericTestSuite` to fix `@Nested` test context inheritance in Spring Framework 7
- Removed 4 deprecated `META-INF/spring.factories` files (`AutoConfiguration.imports` already present)
- MongoDB property `spring.data.mongodb.uri` → `spring.mongodb.uri` (Boot 4 property rename)
- MongoDB UUID representation set to `java-legacy` (Spring Data MongoDB 5.0 changed default)

#### Jackson 2 → Jackson 3
- **Package rename**: `com.fasterxml.jackson.databind` → `tools.jackson.databind`, `com.fasterxml.jackson.core` → `tools.jackson.core` (`com.fasterxml.jackson.annotation` unchanged)
- **Maven groupId**: `com.fasterxml.jackson.core:jackson-databind` → `tools.jackson.core:jackson-databind`, managed via `tools.jackson:jackson-bom` 3.1.0
- **API renames**: `Module` → `JacksonModule`, `JsonDeserializer` → `ValueDeserializer`, `JsonProcessingException` → `JacksonException`, `asText()` → `asString()`, `elements()` → `iterator()`
- **Signature changes**: `deserialize()` now throws `JacksonException` (unchecked) instead of `IOException`; `findBeanDeserializer()` takes `BeanDescription.Supplier` and returns `ValueDeserializer<?>`; `hasDeserializerFor()` now abstract in `Deserializers.Base`
- **ObjectMapper immutability**: Replaced `new ObjectMapper().registerModule()` with `JsonMapper.builder().addModule().build()`
- **JavaTimeModule**: Removed `jackson-datatype-jsr310` dependency (built into Jackson 3 databind)
- **Lombok**: Configured `lombok.jacksonized.jacksonVersion += 3` in `lombok.config` for `@Jacksonized` to generate Jackson 3 annotations
- **Refactoring**: Extracted anonymous `Deserializers.Base` subclass into named `QuerityDeserializers` class for testability and JaCoCo coverage
- Removed `spring-boot-jackson2` backward-compat dependency and `preferred-json-mapper: jackson2` test config

### Test results
All 12 modules pass: **1,321+ tests total**, 0 failures. All JaCoCo coverage thresholds met.

Closes #128
